### PR TITLE
Make the toctree hidden

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,10 +31,8 @@ it. feedback@isb-cgc.org
 
 -- the ISB-CGC team
 
-Contents
-########
-
 .. toctree::
+   :hidden:
    :maxdepth: 1
 
    sections/About-ISB-CGC


### PR DESCRIPTION
Hide the toctree so that the Contents won't display on the main page. It is already displaying on the sidebar.